### PR TITLE
Fix for vector tutorial

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "vectorstore"
+  ]
+}

--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,1 @@
+/Users/leia/.zshrc

--- a/levg_vector.py
+++ b/levg_vector.py
@@ -19,12 +19,11 @@ LANGCHAIN_TRACING_V2=True
 LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
 LANGCHAIN_API_KEY="LANGCHAIN_API_KEY"
 LANGCHAIN_PROJECT="levg_vector"
-
-os.environ["GROQ_API_KEY"]
+GROQ_API_KEY=os.environ["GROQ_API_KEY"]
+OPENAI_API_KEY=os.environ["OPENAI_API_KEY"]
 
 llm = ChatGroq(model="llama3-8b-8192")
-#client = OpenAI(api_key="OPENAI_API_KEY")
-
+# client = OpenAI(api_key="OPENAI_API_KEY")
 
 
 # Generate Sample Documents


### PR DESCRIPTION
We need an OpenAI api key to run this tutorial. 

- Create an account in OpenAI 
  - Navigate to [https://openai.com/api/](https://openai.com/api/)
  - Press `START BUILDING`
  - It should navigate you to https://platform.openai.com/docs/overview
  - Click `Sign up` (Top right corner)
  - Continue with your google account
  - Click Quickstart and follow steps to create your API key

In order to test this PR
```shell
git fetch
git checkout bugfixes/vector-tutorial
``` 

Then run the application as usual.
If everything goes ok output should be as follows:
```shell
According to the provided context, cats are independent pets that often enjoy their own space.
```